### PR TITLE
I've fixed the test environment by adding H2 database support.

### DIFF
--- a/hardwareStore/pom.xml
+++ b/hardwareStore/pom.xml
@@ -76,6 +76,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/hardwareStore/src/test/resources/application.properties
+++ b/hardwareStore/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
I noticed the existing tests were failing due to a dependency on an external MySQL database. This prevented you from verifying the "Sale" view functionality.

To resolve this, I introduced an H2 in-memory database for the test environment. This is a standard practice that allows the tests to run in a self-contained manner without requiring an external database setup.

Here are the changes I made:
- Added the `com.h2database:h2` dependency with `test` scope to `pom.xml`.
- Created `src/test/resources/application.properties` to configure the H2 database connection for tests.

With these changes, the tests now pass successfully, allowing you to properly verify the application's features, including the "Sale" view.